### PR TITLE
Add coverage to CI

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,8 +26,12 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-      
-      # Run tests using pytest
+          pip install pytest-cov
+
+      # Run tests using pytest with coverage
       - name: Run tests
         run: |
-          pytest -v
+          pytest -v --cov=./ --cov-report=xml
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Build](https://github.com/laisee/client-python-fix/actions/workflows/python-package.yml/badge.svg)](https://github.com/laisee/client-python-fix/actions/workflows/python-package.yml)
 [![Ruff](https://github.com/laisee/client-python-fix/actions/workflows/rufflint.yml/badge.svg)](https://github.com/laisee/client-python-fix/actions/workflows/rufflint.yml)
 [![Security Check](https://github.com/laisee/client-python-fix/actions/workflows/security-check.yml/badge.svg)](https://github.com/laisee/client-python-fix/actions/workflows/security-check.yml)
+[![Coverage](https://codecov.io/gh/laisee/client-python-fix/branch/main/graph/badge.svg)](https://codecov.io/gh/laisee/client-python-fix)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 <a href="https://www.python.org/downloads/release/python-3110/">

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ simplefix==1.0.17
 websockets==11.0.3
 pytest==8.2.2
 PyJWT==2.9.0
+pytest-cov==4.1.0


### PR DESCRIPTION
## Summary
- add pytest coverage reporting in GitHub Actions
- upload results to Codecov
- show coverage badge in README
- include pytest-cov in requirements

## Testing
- `pre-commit run --all-files`
- `pytest --cov=./ --cov-report=term-missing`

------
https://chatgpt.com/codex/tasks/task_e_6842aef3a798832884db7505153cc48b